### PR TITLE
simple fix for top buttons

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,9 +17,9 @@
     <div class="mb-5 text-white text-lg">The Linux Desktop for people who want to "get stuff done"</div>
     <br />
     <div>
-        <a class="button cta mr-3" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
-	<a class="button cta mr-3" href="https://en.opensuse.org/Portal:Aeon/InstallGuide">Install Guide</a>
-        <a class="button secondary" href="https://en.opensuse.org/Portal:Aeon">Wiki</a>
+        <a class="button cta mr-3 ib-5" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
+	<a class="button cta mr-3 ib-5" href="https://en.opensuse.org/Portal:Aeon/InstallGuide">Install Guide</a>
+        <a class="button secondary ib-5" href="https://en.opensuse.org/Portal:Aeon">Wiki</a>
     </div>
 </div>
 <div class="warning mt-3">

--- a/docs/theme/css/main.css
+++ b/docs/theme/css/main.css
@@ -108,6 +108,11 @@ ul li {
     padding: 5px 0;
 }
 
+.ib-5 {
+    display: inline-block;
+    margin: 5px 0px;
+}
+
 .mt-5 {
     margin-top: 20px;
 }

--- a/output/index.html
+++ b/output/index.html
@@ -17,9 +17,9 @@
     <div class="mb-5 text-white text-lg">The Linux Desktop for people who want to "get stuff done"</div>
     <br />
     <div>
-        <a class="button cta mr-3" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
-	<a class="button cta mr-3" href="https://en.opensuse.org/Portal:Aeon/InstallGuide">Install Guide</a>
-        <a class="button secondary" href="https://en.opensuse.org/Portal:Aeon">Wiki</a>
+        <a class="button cta mr-3 ib-5" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
+	<a class="button cta mr-3 ib-5" href="https://en.opensuse.org/Portal:Aeon/InstallGuide">Install Guide</a>
+        <a class="button secondary ib-5" href="https://en.opensuse.org/Portal:Aeon">Wiki</a>
     </div>
 </div>
 <div class="warning mt-3">

--- a/output/theme/css/main.css
+++ b/output/theme/css/main.css
@@ -108,6 +108,11 @@ ul li {
     padding: 5px 0;
 }
 
+.ib-5 {
+    display: inline-block;
+    margin: 5px 0px;
+}
+
 .mt-5 {
     margin-top: 20px;
 }

--- a/themes/aeon/static/css/main.css
+++ b/themes/aeon/static/css/main.css
@@ -108,6 +108,11 @@ ul li {
     padding: 5px 0;
 }
 
+.ib-5 {
+    display: inline-block;
+    margin: 5px 0px;
+}
+
 .mt-5 {
     margin-top: 20px;
 }

--- a/themes/aeon/templates/index.html
+++ b/themes/aeon/templates/index.html
@@ -6,9 +6,9 @@
     <div class="mb-5 text-white text-lg">The Linux Desktop for people who want to "get stuff done"</div>
     <br />
     <div>
-        <a class="button cta mr-3" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
-	<a class="button cta mr-3" href="https://en.opensuse.org/Portal:Aeon/InstallGuide">Install Guide</a>
-        <a class="button secondary" href="https://en.opensuse.org/Portal:Aeon">Wiki</a>
+        <a class="button cta mr-3 ib-5" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
+	<a class="button cta mr-3 ib-5" href="https://en.opensuse.org/Portal:Aeon/InstallGuide">Install Guide</a>
+        <a class="button secondary ib-5" href="https://en.opensuse.org/Portal:Aeon">Wiki</a>
     </div>
 </div>
 <div class="warning mt-3">


### PR DESCRIPTION
This version just turns the top three link buttons to inline-blocks so that they have an actual height and don't stack directly on top of each other when the screen width gets too small. Also added top and bottom margins to create some spacing between them.