### PR TITLE
universalize button rows

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,14 +15,13 @@
     <img class="logo" src="./theme/images/logo.svg">
     <h1>openSUSE Aeon</h1>
     <div class="mb-5 text-white text-lg">The Linux Desktop for people who want to "get stuff done"</div>
-    <br />
-    <div>
-        <a class="button cta mr-3" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
-	<a class="button cta mr-3" href="https://en.opensuse.org/Portal:Aeon/InstallGuide">Install Guide</a>
+    <div class="button-row">
+        <a class="button cta" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
+	    <a class="button cta" href="https://en.opensuse.org/Portal:Aeon/InstallGuide">Install Guide</a>
         <a class="button secondary" href="https://en.opensuse.org/Portal:Aeon">Wiki</a>
     </div>
 </div>
-<div class="warning mt-3">
+<div class="warning">
     <img src="./theme/images/exclamation-icon.svg"> <span>openSUSE Aeon is still in a <b>Release Candidate</b>
         stage!</span>
 </div>

--- a/docs/theme/css/main.css
+++ b/docs/theme/css/main.css
@@ -197,7 +197,11 @@ section:nth-of-type(odd) a{
 .button-row {
     display: flex;
     align-items: center;
-    justify-content: space-evenly;
+    justify-content: center;
+}
+
+.button-row .button {
+    margin: 10px;
 }
 
 #content {
@@ -245,9 +249,5 @@ footer {
         flex-direction: column;
     }
 
-    .button-row .button {
-        margin-bottom: 10px;
-
-    }
 }
 

--- a/output/index.html
+++ b/output/index.html
@@ -15,14 +15,13 @@
     <img class="logo" src="./theme/images/logo.svg">
     <h1>openSUSE Aeon</h1>
     <div class="mb-5 text-white text-lg">The Linux Desktop for people who want to "get stuff done"</div>
-    <br />
-    <div>
-        <a class="button cta mr-3" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
-	<a class="button cta mr-3" href="https://en.opensuse.org/Portal:Aeon/InstallGuide">Install Guide</a>
+    <div class="button-row">
+        <a class="button cta" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
+	    <a class="button cta" href="https://en.opensuse.org/Portal:Aeon/InstallGuide">Install Guide</a>
         <a class="button secondary" href="https://en.opensuse.org/Portal:Aeon">Wiki</a>
     </div>
 </div>
-<div class="warning mt-3">
+<div class="warning">
     <img src="./theme/images/exclamation-icon.svg"> <span>openSUSE Aeon is still in a <b>Release Candidate</b>
         stage!</span>
 </div>

--- a/output/theme/css/main.css
+++ b/output/theme/css/main.css
@@ -197,7 +197,11 @@ section:nth-of-type(odd) a{
 .button-row {
     display: flex;
     align-items: center;
-    justify-content: space-evenly;
+    justify-content: center;
+}
+
+.button-row .button {
+    margin: 10px;
 }
 
 #content {
@@ -245,9 +249,5 @@ footer {
         flex-direction: column;
     }
 
-    .button-row .button {
-        margin-bottom: 10px;
-
-    }
 }
 

--- a/themes/aeon/static/css/main.css
+++ b/themes/aeon/static/css/main.css
@@ -197,7 +197,11 @@ section:nth-of-type(odd) a{
 .button-row {
     display: flex;
     align-items: center;
-    justify-content: space-evenly;
+    justify-content: center;
+}
+
+.button-row .button {
+    margin: 10px;
 }
 
 #content {
@@ -245,9 +249,5 @@ footer {
         flex-direction: column;
     }
 
-    .button-row .button {
-        margin-bottom: 10px;
-
-    }
 }
 

--- a/themes/aeon/templates/index.html
+++ b/themes/aeon/templates/index.html
@@ -4,14 +4,13 @@
     <img class="logo" src="{{SITEURL}}/theme/images/logo.svg">
     <h1>openSUSE Aeon</h1>
     <div class="mb-5 text-white text-lg">The Linux Desktop for people who want to "get stuff done"</div>
-    <br />
-    <div>
-        <a class="button cta mr-3" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
-	<a class="button cta mr-3" href="https://en.opensuse.org/Portal:Aeon/InstallGuide">Install Guide</a>
+    <div class="button-row">
+        <a class="button cta" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
+	    <a class="button cta" href="https://en.opensuse.org/Portal:Aeon/InstallGuide">Install Guide</a>
         <a class="button secondary" href="https://en.opensuse.org/Portal:Aeon">Wiki</a>
     </div>
 </div>
-<div class="warning mt-3">
+<div class="warning">
     <img src="{{SITEURL}}/theme/images/exclamation-icon.svg"> <span>openSUSE Aeon is still in a <b>Release Candidate</b>
         stage!</span>
 </div>


### PR DESCRIPTION
This fix is a bit more complicated, but maybe a bit more structurally neat and future-proof.
The top three buttons get put into a button row, just as the chat room buttons further down already were. I then adjusted the button-row properties a bit so that it looks okay for both the top three and the later two buttons at the bottom.

Also slightly adjusted the above-fold layout to account for the new extra margins.