### PR TITLE
Focus Aeon as a standalone brand

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-        <title>openSUSE Aeon</title>
+        <title>Aeon</title>
         <meta charset="utf-8" />
         <meta name="generator" content="Pelican" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -13,7 +13,7 @@
           <div id="above-the-fold">
 <div class="above-the-fold-wrapper">
     <img class="logo" src="./theme/images/logo.svg">
-    <h1>openSUSE Aeon</h1>
+    <h1>Aeon</h1>
     <div class="mb-5 text-white text-lg">The Linux Desktop for people who want to "get stuff done"</div>
     <div class="button-row">
         <a class="button cta" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
@@ -22,7 +22,7 @@
     </div>
 </div>
 <div class="warning">
-    <img src="./theme/images/exclamation-icon.svg"> <span>openSUSE Aeon is still in a <b>Release Candidate</b>
+    <img src="./theme/images/exclamation-icon.svg"> <span>Aeon is still in a <b>Release Candidate</b>
         stage!</span>
 </div>
           </div>
@@ -117,7 +117,7 @@
 
             <li class="text-md">
                 Your current RPM packages are supported by transactional-update, as well as most of the packages in
-                openSUSE's repos.
+                Aeon's repos.
             </li>
         </ul>
     </div>
@@ -185,7 +185,7 @@
         </div>
         </main>
         <footer>
-          © openSUSE contributors
+          © Aeon contributors
         </footer>
 </body>
 </html>

--- a/output/archives.html
+++ b/output/archives.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-        <title>openSUSE Aeon - Archives</title>
+        <title>Aeon - Archives</title>
         <meta charset="utf-8" />
         <meta name="generator" content="Pelican" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -11,17 +11,17 @@
 <body>
         <main>
           <div id="above-the-fold">
-            <h1>openSUSE Aeon</h1>
+            <h1>Aeon</h1>
           </div>
           <div id="content">
-<h2>Archives for openSUSE Aeon</h2>
+<h2>Archives for Aeon</h2>
 
 <dl>
 </dl>
         </div>
         </main>
         <footer>
-          © openSUSE contributors
+          © Aeon contributors
         </footer>
 </body>
 </html>

--- a/output/authors.html
+++ b/output/authors.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-        <title>openSUSE Aeon - Authors</title>
+        <title>Aeon - Authors</title>
         <meta charset="utf-8" />
         <meta name="generator" content="Pelican" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -11,16 +11,16 @@
 <body>
         <main>
           <div id="above-the-fold">
-            <h1>openSUSE Aeon</h1>
+            <h1>Aeon</h1>
           </div>
           <div id="content">
-    <h2>Authors on openSUSE Aeon</h2>
+    <h2>Authors on Aeon</h2>
     <ul>
     </ul>
         </div>
         </main>
         <footer>
-          © openSUSE contributors
+          © Aeon contributors
         </footer>
 </body>
 </html>

--- a/output/categories.html
+++ b/output/categories.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-        <title>openSUSE Aeon - Categories</title>
+        <title>Aeon - Categories</title>
         <meta charset="utf-8" />
         <meta name="generator" content="Pelican" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -11,16 +11,16 @@
 <body>
         <main>
           <div id="above-the-fold">
-            <h1>openSUSE Aeon</h1>
+            <h1>Aeon</h1>
           </div>
           <div id="content">
-    <h2>Categories on openSUSE Aeon</h2>
+    <h2>Categories on Aeon</h2>
     <ul>
     </ul>
         </div>
         </main>
         <footer>
-          © openSUSE contributors
+          © Aeon contributors
         </footer>
 </body>
 </html>

--- a/output/category/review.html
+++ b/output/category/review.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-        <title>openSUSE Aeon - Review category</title>
+        <title>Aeon - Review category</title>
         <meta charset="utf-8" />
         <meta name="generator" content="Pelican" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -13,7 +13,7 @@
           <div id="above-the-fold">
     <div class="above-the-fold-wrapper">
         <img class="logo" src="../theme/images/logo.svg">
-        <h1>openSUSE Aeon</h1>
+        <h1>Aeon</h1>
         <div class="mb-5 text-white text-lg">For developers who want to "get stuff done"</div>
         <div>
             <a class="button cta mr-3" href="https://en.opensuse.org/Portal:MicroOS/Downloads">Download</a>
@@ -21,7 +21,7 @@
         </div>
     </div>
     <div class="warning mt-3">
-        <img src="../theme/images/exclamation-icon.svg"> <span>openSUSE Aeon is still in a <b>Release Candidate</b> stage!</span>
+        <img src="../theme/images/exclamation-icon.svg"> <span>Aeon is still in a <b>Release Candidate</b> stage!</span>
     </div>
           </div>
           <div id="content">
@@ -87,7 +87,7 @@
         </li>
 
         <li class="text-md">
-            Your current RPM packages are supported by transactional-update, as well as all of the packages in openSUSE's repos.
+            Your current RPM packages are supported by transactional-update, as well as all of the packages in Aeon's repos.
         </li>
     </ul>
 
@@ -150,7 +150,7 @@
         </div>
         </main>
         <footer>
-          © openSUSE contributors
+          © Aeon contributors
         </footer>
 </body>
 </html>

--- a/output/index.html
+++ b/output/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-        <title>openSUSE Aeon</title>
+        <title>Aeon</title>
         <meta charset="utf-8" />
         <meta name="generator" content="Pelican" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -13,7 +13,7 @@
           <div id="above-the-fold">
 <div class="above-the-fold-wrapper">
     <img class="logo" src="./theme/images/logo.svg">
-    <h1>openSUSE Aeon</h1>
+    <h1>Aeon</h1>
     <div class="mb-5 text-white text-lg">The Linux Desktop for people who want to "get stuff done"</div>
     <div class="button-row">
         <a class="button cta" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
@@ -22,7 +22,7 @@
     </div>
 </div>
 <div class="warning">
-    <img src="./theme/images/exclamation-icon.svg"> <span>openSUSE Aeon is still in a <b>Release Candidate</b>
+    <img src="./theme/images/exclamation-icon.svg"> <span>Aeon is still in a <b>Release Candidate</b>
         stage!</span>
 </div>
           </div>
@@ -117,7 +117,7 @@
 
             <li class="text-md">
                 Your current RPM packages are supported by transactional-update, as well as most of the packages in
-                openSUSE's repos.
+                Aeon's repos.
             </li>
         </ul>
     </div>
@@ -185,7 +185,7 @@
         </div>
         </main>
         <footer>
-          © openSUSE contributors
+          © Aeon contributors
         </footer>
 </body>
 </html>

--- a/output/tags.html
+++ b/output/tags.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-        <title>openSUSE Aeon - Tags</title>
+        <title>Aeon - Tags</title>
         <meta charset="utf-8" />
         <meta name="generator" content="Pelican" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -11,16 +11,16 @@
 <body>
         <main>
           <div id="above-the-fold">
-            <h1>openSUSE Aeon</h1>
+            <h1>Aeon</h1>
           </div>
           <div id="content">
-    <h2>Tags for openSUSE Aeon</h2>
+    <h2>Tags for Aeon</h2>
     <ul>
     </ul>
         </div>
         </main>
         <footer>
-          © openSUSE contributors
+          © Aeon contributors
         </footer>
 </body>
 </html>

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -1,5 +1,5 @@
-AUTHOR = 'openSUSE Contributors'
-SITENAME = 'openSUSE Aeon'
+AUTHOR = 'Aeon Contributors'
+SITENAME = 'Aeon'
 SITEURL = ""
 
 PATH = "content"

--- a/themes/aeon/templates/base.html
+++ b/themes/aeon/templates/base.html
@@ -41,7 +41,7 @@
         <main>
           <div id="above-the-fold">
           {% block above_the_fold %}
-            <h1>openSUSE Aeon</h1>
+            <h1>Aeon</h1>
           {% endblock above_the_fold%}
           </div>
           <div id="content">
@@ -50,7 +50,7 @@
         </div>
         </main>
         <footer>
-          © openSUSE contributors
+          © Aeon contributors
         </footer>
 </body>
 </html>

--- a/themes/aeon/templates/index.html
+++ b/themes/aeon/templates/index.html
@@ -2,7 +2,7 @@
 {% block above_the_fold %}
 <div class="above-the-fold-wrapper">
     <img class="logo" src="{{SITEURL}}/theme/images/logo.svg">
-    <h1>openSUSE Aeon</h1>
+    <h1>Aeon</h1>
     <div class="mb-5 text-white text-lg">The Linux Desktop for people who want to "get stuff done"</div>
     <div class="button-row">
         <a class="button cta" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
@@ -11,7 +11,7 @@
     </div>
 </div>
 <div class="warning">
-    <img src="{{SITEURL}}/theme/images/exclamation-icon.svg"> <span>openSUSE Aeon is still in a <b>Release Candidate</b>
+    <img src="{{SITEURL}}/theme/images/exclamation-icon.svg"> <span>Aeon is still in a <b>Release Candidate</b>
         stage!</span>
 </div>
 {% endblock %}
@@ -107,7 +107,7 @@
 
             <li class="text-md">
                 Your current RPM packages are supported by transactional-update, as well as most of the packages in
-                openSUSE's repos.
+                Aeon's repos.
             </li>
         </ul>
     </div>


### PR DESCRIPTION
As I'll be presenting at the openSUSE Conference (https://events.opensuse.org/conferences/oSC24/program/proposals/4411) there is a combined wish from SUSE and some of the community to de-emphasise/drop the openSUSE brand and go forward focusing on establishing strong brands for individual projects

This PR is an expression of Aeon's first step in this direction, dropping the term "openSUSE" from the website

Please do not merge yet. This is here to help frame discussions, which will need some time to occur