### PR TITLE
RC3: Use new URL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
     <h1>Aeon Desktop</h1>
     <div class="mb-5 text-white text-lg">The Linux Desktop for people who want to "get stuff done"</div>
     <div class="button-row">
-        <a class="button cta" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
+        <a class="button cta" href="https://download.opensuse.org/tumbleweed/appliances/Aeon-Installer.x86_64.raw.xz">Download</a>
         <a class="button cta" href="https://en.opensuse.org/Portal:Aeon/InstallGuide">Install Guide</a>
         <a class="button secondary" href="https://en.opensuse.org/Portal:Aeon">Documentation</a>
     </div>

--- a/output/index.html
+++ b/output/index.html
@@ -17,7 +17,7 @@
     <h1>Aeon Desktop</h1>
     <div class="mb-5 text-white text-lg">The Linux Desktop for people who want to "get stuff done"</div>
     <div class="button-row">
-        <a class="button cta" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
+        <a class="button cta" href="https://download.opensuse.org/tumbleweed/appliances/Aeon-Installer.x86_64.raw.xz">Download</a>
         <a class="button cta" href="https://en.opensuse.org/Portal:Aeon/InstallGuide">Install Guide</a>
         <a class="button secondary" href="https://en.opensuse.org/Portal:Aeon">Documentation</a>
     </div>

--- a/themes/aeon/templates/index.html
+++ b/themes/aeon/templates/index.html
@@ -5,7 +5,7 @@
     <h1>Aeon Desktop</h1>
     <div class="mb-5 text-white text-lg">The Linux Desktop for people who want to "get stuff done"</div>
     <div class="button-row">
-        <a class="button cta" href="https://download.opensuse.org/tumbleweed/appliances/openSUSE-Aeon-Installer.x86_64.raw.xz">Download</a>
+        <a class="button cta" href="https://download.opensuse.org/tumbleweed/appliances/Aeon-Installer.x86_64.raw.xz">Download</a>
         <a class="button cta" href="https://en.opensuse.org/Portal:Aeon/InstallGuide">Install Guide</a>
         <a class="button secondary" href="https://en.opensuse.org/Portal:Aeon">Documentation</a>
     </div>


### PR DESCRIPTION
RC3 changes Aeon's URL to one without the openSUSE Brand

But the current image 0725 isn't in a great state for people to use

So merge and deploy this when RC3 actually is out