### PR TITLE
Update main.css

### DIFF
--- a/themes/aeon/static/css/main.css
+++ b/themes/aeon/static/css/main.css
@@ -1,25 +1,25 @@
 :root {
   --primary-color: oklab(66% -0.13 0.03);
   --primary-darker-color: oklab(50% -0.1 0.02);
-  --text-color: #000000;
-  --heading-color: #000000;
-  --primary-body: #fff;
-  --secondary-body: #f6f6f6;
+  --text-color: #1a2421;
+  --heading-color: #1a2421;
+  --primary-body: #fbfefd;
+  --secondary-body: #e9f6ef;
   --yellow-100: #fef08a66;
   --yellow-500: #fde04788;
-  --shadow-color: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-color: 0 4px 6px -1px #1a242120, 0 2px 4px -1px #1a242110;
   --transition-duration: 0.15s;
   --container-max-width: 1200px;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --text-color: #fff;
-    --heading-color: #fff;
-    --primary-body: #000;
-    --secondary-body: #111111;
-    --shadow-color: 0 4px 6px -1px rgba(255, 255, 255, 0.2), 0 2px 4px -1px rgba(255, 255, 255, 0.06);
-  }
+    --text-color: #fbfefd;
+    --heading-color: #fbfefd;
+    --primary-body: #1a2421;
+    --secondary-body: #3a4340;
+    --shadow-color: 0 4px 6px -1px #fbfefd20, 0 2px 4px -1px #fbfefd10;
+ }
   .flip {
     filter: invert();
   }
@@ -168,6 +168,7 @@ a:hover {
 
 .jumbotron-content {
   width: 100%;
+  color: #e9f6ef;
 }
  @media (min-width: 768px) {
   .jumbotron-content{
@@ -179,7 +180,7 @@ a:hover {
   font-size: 2.25rem;
   line-height: 2.5rem;
   font-weight: 700;
-  color: var(--heading-color);
+  color: #fbfefd;
   margin-bottom: 1rem;
 }
 


### PR DESCRIPTION
- Changed primary and heading colours to avoid pure white and pure black in light and dark variants, respectively.
- Changed secondary colours to have a greenish tint which better matches main colours and improves contrast (specially on the dark variant)
- Changed the hero (jumbotron) to be always light to improve contrast on light theme (as the background is always the same green)